### PR TITLE
Use own class name in ActivemqConnectorService debug message

### DIFF
--- a/uk.ac.diamond.daq.activemq.connector/src/uk/ac/diamond/daq/activemq/connector/ActivemqConnectorService.java
+++ b/uk.ac.diamond.daq.activemq.connector/src/uk/ac/diamond/daq/activemq/connector/ActivemqConnectorService.java
@@ -29,7 +29,7 @@ public class ActivemqConnectorService implements IEventConnectorService {
 	}
 
 	static {
-		System.out.println("Started "+IEventConnectorService.class.getSimpleName());
+		System.out.println("Started " + ActivemqConnectorService.class.getSimpleName());
 	}
 
 	/**


### PR DESCRIPTION
Assuming we want this `println` at all, it seems more sensible to report using the class' own name, rather than the interface it implements.
