### PR TITLE
Clean up EventException

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/EventException.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/event/EventException.java
@@ -2,29 +2,26 @@ package org.eclipse.scanning.api.event;
 
 public class EventException extends Exception {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -6644630244716886256L;
 
 	public EventException() {
 		super();
 	}
 
-	public EventException(String arg0, Throwable arg1, boolean arg2,
-			boolean arg3) {
-		super(arg0, arg1, arg2, arg3);
+	public EventException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
 	}
 
-	public EventException(String arg0, Throwable arg1) {
-		super(arg0, arg1);
+	public EventException(String message, Throwable throwable) {
+		super(message, throwable);
 	}
 
-	public EventException(String arg0) {
-		super(arg0);
+	public EventException(String message) {
+		super(message);
 	}
 
-	public EventException(Throwable arg0) {
-		super(arg0);	}
+	public EventException(Throwable throwable) {
+		super(throwable);
+	}
 
 }


### PR DESCRIPTION
Mainly, use the same argument names as in `Exception`.
