### PR TITLE
Add org.eclipse.scanning.example to org.eclipse.scanning.feature

### DIFF
--- a/org.eclipse.scanning.feature/feature.xml
+++ b/org.eclipse.scanning.feature/feature.xml
@@ -98,4 +98,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.scanning.example"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
This should fix the broken Dawn build.
