### PR TITLE
Prevent NPE dereferencing scannableNames before null check

### DIFF
--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/NexusScanFileBuilder.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/nexus/NexusScanFileBuilder.java
@@ -115,7 +115,7 @@ public class NexusScanFileBuilder {
 	}
 	
 	private List<NexusObjectProvider<?>> getNexusScannables(List<String> scannableNames, NexusScanInfo scanInfo) throws ScanningException {
-		final List<IScannable<?>> scannables = new ArrayList<>(scannableNames.isEmpty() ? 0 : scannableNames.size());
+		final List<IScannable<?>> scannables = new ArrayList<>();
 		if (scannableNames != null) for (String scannableName : scannableNames) {
 			IScannable<?> scannable = deviceService.getScannable(scannableName);
 			if (scannable == null) {


### PR DESCRIPTION
The dereferening was only used to initalise a ArrayList initial capacity
so removed this.

Signed-off-by: James Mudd james.mudd@diamond.ac.uk
