### PR TITLE
Adds setActive(true) to allow restarting of a stopped consumer.

### DIFF
--- a/org.eclipse.scanning.event/src/org/eclipse/scanning/event/ConsumerImpl.java
+++ b/org.eclipse.scanning.event/src/org/eclipse/scanning/event/ConsumerImpl.java
@@ -269,6 +269,7 @@ public class ConsumerImpl<U extends StatusBean> extends AbstractQueueConnection<
 				}
 			}
 		};
+		setActive(true);
 		consumerThread.setDaemon(true);
 		consumerThread.setPriority(Thread.NORM_PRIORITY-1);
 		consumerThread.start();


### PR DESCRIPTION
active must be true for consumer to run through messages. Setting active in start() allows stopped consumers to be restarted.

Signed-off-by: Michael Wharmby michael.wharmby@diamond.ac.uk
