### PR TITLE
Refactor to move HDF object code to their own packages

### DIFF
--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/device/MockedWriteInLoopPausableMalcolmDevice.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/device/MockedWriteInLoopPausableMalcolmDevice.java
@@ -5,8 +5,8 @@ import java.util.concurrent.Callable;
 
 import org.eclipse.dawnsci.analysis.api.dataset.IDataset;
 import org.eclipse.dawnsci.analysis.dataset.impl.Random;
-import org.eclipse.dawnsci.hdf5.HierarchicalDataFactory;
-import org.eclipse.dawnsci.hdf5.IHierarchicalDataFile;
+import org.eclipse.dawnsci.hdf.object.HierarchicalDataFactory;
+import org.eclipse.dawnsci.hdf.object.IHierarchicalDataFile;
 import org.eclipse.scanning.api.event.scan.DeviceState;
 import org.eclipse.scanning.api.malcolm.MalcolmDeviceException;
 import org.eclipse.scanning.api.malcolm.event.MalcolmEventBean;


### PR DESCRIPTION
Moving things around before splitting out the hierarchical data stuff.
