### PR TITLE
Fix NPE on class loading

### DIFF
--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/DeviceServiceImpl.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/DeviceServiceImpl.java
@@ -73,17 +73,15 @@ public final class DeviceServiceImpl implements IDeviceService {
 		System.out.println("Starting device service");
 		Map<Class<?>, Class<? extends IRunnableDevice>> aqui = new HashMap<>(7);
 		aqui.put(ScanModel.class,         AcquisitionDevice.class);
-		
+
+		modelledDevices  = aqui;
+		namedDevices       = new HashMap<>(3);
+
 		try {
 			readExtensions(aqui);
 		} catch (CoreException e) {
 			e.printStackTrace(); // Static block, intentionally do not use logging.
 		}
-
-		
-		modelledDevices  = aqui;
-		namedDevices       = new HashMap<>(3);
-
 	}
 	
 	


### PR DESCRIPTION
readExtensions() was trying to add a device to namedDevices before it
had been initialised

Using the same ticket that was referenced on the commit that introduced
the problem:
http://jira.diamond.ac.uk/browse/DAQ-56
