### PR TITLE
Fix failing scan tests relating to ScanningException messages

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/AbstractRunnableDevice.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/AbstractRunnableDevice.java
@@ -111,7 +111,7 @@ public abstract class AbstractRunnableDevice<T> implements IRunnableEventDevice<
 	
 	public void start(final IPosition pos) throws ScanningException, InterruptedException {
 		
-		final List<Throwable> exceptions = new ArrayList<>(1);
+		final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<>(1));
 		final Thread thread = new Thread(new Runnable() {
 			public void run() {
 				try {

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/AbstractRunnableDevice.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/AbstractRunnableDevice.java
@@ -117,6 +117,9 @@ public abstract class AbstractRunnableDevice<T> implements IRunnableEventDevice<
 				try {
 					AbstractRunnableDevice.this.run(pos);
 				} catch (ScanningException|InterruptedException e) {
+					// If you add an exception type to this catch clause,
+					// you must also add an "else if" clause for it inside
+					// the "if (!exceptions.isEmpty())" conditional below.
 					e.printStackTrace();
 					exceptions.add(e);
 				}
@@ -128,7 +131,22 @@ public abstract class AbstractRunnableDevice<T> implements IRunnableEventDevice<
 		// immediately throw any connection exceptions
 		Thread.sleep(500);
 		
-		if (!exceptions.isEmpty()) throw new ScanningException(exceptions.get(0));
+		// Re-throw any exception from the thread.
+		if (!exceptions.isEmpty()) {
+			Throwable ex = exceptions.get(0);
+
+			// We must manually match the possible exception types because Java
+			// doesn't let us do List<Either<ScanningException, InterruptedException>>.
+			if (ex.getClass() == ScanningException.class) {
+				throw (ScanningException) ex;
+
+			} else if (ex.getClass() == InterruptedException.class) {
+				throw (InterruptedException) ex;
+
+			} else {
+				throw new IllegalStateException();
+			}
+		}
 	}
 
 	/**

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AbstractScanTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AbstractScanTest.java
@@ -25,12 +25,12 @@ import org.eclipse.scanning.api.event.scan.DeviceState;
 import org.eclipse.scanning.api.event.scan.IScanListener;
 import org.eclipse.scanning.api.event.scan.ScanBean;
 import org.eclipse.scanning.api.event.scan.ScanEvent;
-import org.eclipse.scanning.api.points.GeneratorException;
 import org.eclipse.scanning.api.points.IPointGenerator;
 import org.eclipse.scanning.api.points.IPointGeneratorService;
 import org.eclipse.scanning.api.points.IPosition;
 import org.eclipse.scanning.api.points.MapPosition;
 import org.eclipse.scanning.api.points.Point;
+import org.eclipse.scanning.api.points.PointsValidationException;
 import org.eclipse.scanning.api.points.models.AbstractPointsModel;
 import org.eclipse.scanning.api.points.models.BoundingBox;
 import org.eclipse.scanning.api.points.models.GridModel;
@@ -205,11 +205,13 @@ public class AbstractScanTest {
 			Thread.sleep(5000);  // testStepScan (the valid one) takes ~2 seconds total.
 			
 		} catch (Exception ex) {
-			assertEquals("Model step is directed backwards!", ex.getMessage());
+			assertEquals(ScanningException.class, ex.getClass());
+			assertEquals(PointsValidationException.class, ex.getCause().getClass());
+			assertEquals("Model step is directed backwards!", ex.getCause().getMessage());
 			return;
 		}
 		
-		throw new Exception("Generator failed to throw GeneratorException(\"Model step is directed backwards!\") on invalid step model input.");
+		throw new Exception("Scanner failed to throw an exception.");
 	}
 
 	@Test
@@ -230,11 +232,13 @@ public class AbstractScanTest {
 			Thread.sleep(5000);  // testStepScan (the valid one) takes ~2 seconds total.
 			
 		} catch (Exception ex) {
-			assertEquals("Model step size must be nonzero!", ex.getMessage());
+			assertEquals(ScanningException.class, ex.getClass());
+			assertEquals(PointsValidationException.class, ex.getCause().getClass());
+			assertEquals("Model step size must be nonzero!", ex.getCause().getMessage());
 			return;
 		}
 		
-		throw new Exception("Generator failed to throw GeneratorException(\"Model step size must be nonzero!\") on invalid step model input.");
+		throw new Exception("Scanner failed to throw an exception.");
 	}
 	
 	


### PR DESCRIPTION
@gerring This PR still doesn't mean that `myScanningException.getMessage()` will necessarily produce a string without the word "PointsValidationException". It is the responsibility of the GUI creator to call `.getCause().getMessage()` as necessary if they want the root cause message without any extraneous exception class names.

Does this sound reasonable? :) Or should I do more work in `AbstractRunnableDevice.start()` to make sure that the `ScanningException` always gets a "nice" error message (possibly overriding an important message placed in the `ScanningException` by implementers of `AbstractRunnableDevice.run()`)?

This PR also makes the exceptions list in `AbstractRunnableDevice.start()` threadsafe.
