### PR TITLE
Remove incorrect activate method for QueueServicesHolder

### DIFF
--- a/org.eclipse.scanning.event/OSGI-INF/queueServicesHolder.xml
+++ b/org.eclipse.scanning.event/OSGI-INF/queueServicesHolder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="start" immediate="true" name="Queue Service and subsystems Service Holder">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="Queue Service and subsystems Service Holder">
    <implementation class="org.eclipse.scanning.event.queues.QueueServicesHolder"/>
    <reference bind="setDeviceService" cardinality="1..1" interface="org.eclipse.scanning.api.device.IRunnableDeviceService" name="IRunnableDeviceService" policy="static" unbind="unsetDeviceService"/>
    <reference bind="setEventService" cardinality="1..1" interface="org.eclipse.scanning.api.event.IEventService" name="IEventService" policy="static" unbind="unsetEventService"/>


### PR DESCRIPTION
There is no start() in org.eclipse.scanning.event.queues.QueueServicesHolder
