### PR TITLE
Explicitly use HashMaps in Jython scan requests

### DIFF
--- a/org.eclipse.scanning.command/scripts/mapping_scan_commands.py
+++ b/org.eclipse.scanning.command/scripts/mapping_scan_commands.py
@@ -41,6 +41,7 @@ interest (ROI) when using grid(). They are: circ(), rect(), poly().
 #
 #   mscan() will send your updated detector model as part of the ScanRequest.
 
+from java.util import HashMap
 from java.net import URI
 from org.eclipse.dawnsci.analysis.dataset.roi import (
     CircularROI, RectangularROI, PolygonalROI, PolylineROI, PointROI)
@@ -143,16 +144,17 @@ def scan_request(path=None, mon=None, det=None, allow_preprocess=False):
 
     # ScanRequest expects ROIs to be specified as a map in the following
     # (bizarre?) format:
-    roi_map = {}  # No dict comprehensions in Python 2.5!
+    # (Use a HashMap here (not a plain Python dict) because otherwise run-time
+    # errors occur if someone later calls scanRequest.getRegions().hashCode().)
+    roi_map = HashMap()
     for (model, rois) in scan_paths:
         if len(rois) > 0:
             roi_map[model.getUniqueKey()] = rois
-    # Nicer Python 2.7 version for if the Jython interpreter is ever upgraded:
-    # roi_map = {model.getUniqueKey(): rois
-    #            for (model, rois) in scan_paths if len(rois) > 0}
 
-    detector_map = dict(detectors)
-    # Equivalent to (Python 2.7) {name: model for (name, model) in detectors}.
+    # (Again, use a HashMap, not a Python dict.)
+    detector_map = HashMap()
+    for (name, model) in detectors:
+        detector_map[name] = model
 
     return _instantiate(ScanRequest,
                         {'models': scan_path_models,

--- a/org.eclipse.scanning.command/scripts/mapping_scan_commands.py
+++ b/org.eclipse.scanning.command/scripts/mapping_scan_commands.py
@@ -106,7 +106,8 @@ def submit(request, now=False, block=True,
 
     See the mscan() docstring for details of `now` and `block`.
     """
-    scan_bean = _instantiate(ScanBean, {'scanRequest': request})
+    scan_bean = _instantiate(ScanBean, {'scanRequest': request,
+                                        'name': '(Jython scan request)'})
 
     if now:
         raise NotImplementedError()  # TODO: Raise priority.


### PR DESCRIPTION
This fixes a bug encountered in the GUI whereby one of the `HashMap` fields of `ScanRequest` would have its `hashCode` method called - but since it wasn't a true `HashMap` (but only a Jython `dict` masquerading as one) the `hashCode` method would throw an uncaught exception, because Python `dict`s are unhashable.

It's a bit worrying that Jython will happily coerce Python objects into Java types in a way that results in non-obvious runtime exceptions like this...

P.S. @jamesmudd I think this was the cause of the `org.python.core.PyException` you saw a couple of weeks ago.
