### PR TITLE
Prevent warning messages about missing methods

### DIFF
--- a/org.eclipse.scanning.event/src/org/eclipse/scanning/event/queues/AtomQueueService.java
+++ b/org.eclipse.scanning.event/src/org/eclipse/scanning/event/queues/AtomQueueService.java
@@ -97,10 +97,10 @@ public class AtomQueueService implements IQueueService {
 		eventService = evServ;
 	}
 	
-	public synchronized void unsetEventService() {
+	public synchronized void unsetEventService(IEventService evServ) {
 		try {
-			stop(true);
-		} catch(EventException ex) {
+			if (alive) stop(true);
+		} catch (Exception ex) {
 			logger.error("Error stopping the queue service");
 		}
 		eventService = null;
@@ -144,7 +144,8 @@ public class AtomQueueService implements IQueueService {
 		//Dispose the job queue
 		disposeQueue(getJobQueueID(), true);
 	}
-		
+
+	@Override
 	public void start() throws EventException {
 		if (!jobQueue.getQueueStatus().isStartable()) {
 			throw new EventException("Job queue not startable - Status: " + jobQueue.getQueueStatus());

--- a/org.eclipse.scanning.event/src/org/eclipse/scanning/event/queues/QueueServicesHolder.java
+++ b/org.eclipse.scanning.event/src/org/eclipse/scanning/event/queues/QueueServicesHolder.java
@@ -26,8 +26,10 @@ public final class QueueServicesHolder {
 		QueueServicesHolder.deviceService = deviceService;
 	}
 
-	public static void unsetDeviceService() {
-		QueueServicesHolder.deviceService = null;
+	public static void unsetDeviceService(IRunnableDeviceService deviceService) {
+		if (QueueServicesHolder.deviceService == deviceService) {
+			QueueServicesHolder.deviceService = null;
+		}
 	}
 
 	public static IEventService getEventService() {
@@ -38,8 +40,10 @@ public final class QueueServicesHolder {
 		QueueServicesHolder.eventService = eventService;
 	}
 
-	public static void unsetEventService() {
-		QueueServicesHolder.eventService = null;
+	public static void unsetEventService(IEventService eventService) {
+		if (QueueServicesHolder.eventService == eventService) {
+			QueueServicesHolder.eventService = null;
+		}
 	}
 
 	public static IQueueService getQueueService() {
@@ -50,8 +54,10 @@ public final class QueueServicesHolder {
 		QueueServicesHolder.queueService = queueService;
 	}
 
-	public static void unsetQueueService() {
-		QueueServicesHolder.queueService = null;
+	public static void unsetQueueService(IQueueService queueService) {
+		if (QueueServicesHolder.queueService == queueService) {
+			QueueServicesHolder.queueService = null;
+		}
 	}
 
 }


### PR DESCRIPTION
Service unset methods need to take an instance of the service as an
argument, otherwise they are not identified and the OSGi framework
logs warnings about the methods not existing.

Also, this commit prevents exceptions and error messages on application
shutdown which occurred if the AtomQueueService had not been started.
