### PR TITLE
DAQ-201 (9.2pre) Add .gitignore to uk.ac.diamond.daq.malcolm.connector

### DIFF
--- a/uk.ac.diamond.daq.malcolm.connector/.gitignore
+++ b/uk.ac.diamond.daq.malcolm.connector/.gitignore
@@ -1,0 +1,44 @@
+### Temporary files ###
+*.bak
+*.swp
+*.tmp
+*.*~
+
+### Java ###
+*.class
+hs_err_pid*
+derby.log
+
+### Python / Jython ###
+__pycache__/
+*.py[cod]
+jythonCache/
+cachedir/
+
+### Build output ###
+.springBeans
+/bin/
+/classes/
+/src/corba/
+
+### JUnit testing ###
+/activemq-data
+/test-reports
+/test-scratch
+
+### Security files ###
+*.ppk
+*ssh.key
+id_rsa
+password
+passwords
+
+### Various OS, etc. files ###
+*.lnk
+.DS_Store
+[Dd]esktop.ini
+.nfs[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]*
+.svn/
+Thumbs.db
+$RECYCLE.BIN/
+.Trash-*


### PR DESCRIPTION
Missing a gitignore, so git tells you lots of .class files are not committed.
