### PR TITLE
Added check for null listeners in _Scannable.

### DIFF
--- a/org.eclipse.scanning.event/src/org/eclipse/scanning/event/remote/_Scannable.java
+++ b/org.eclipse.scanning.event/src/org/eclipse/scanning/event/remote/_Scannable.java
@@ -170,6 +170,7 @@ class _Scannable<T> extends _AbstractRemoteDevice<T> implements IScannable<T>, I
 			subscriber.addListener(getName(), new ILocationListener() {
 				@Override
 				public void locationPerformed(LocationEvent evt) {
+					if (listeners == null) return;
 
 					lastActive = System.currentTimeMillis();
 					final Location      loc  = evt.getLocation();


### PR DESCRIPTION
This causes a printed error in the tests, although they still pass.
