### PR TITLE
Rollback change to put exluders into compound generators

### DIFF
--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/CompoundIterator.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/CompoundIterator.java
@@ -57,7 +57,7 @@ public class CompoundIterator extends AbstractScanPointIterator {
 		
 		JythonObjectFactory compoundGeneratorFactory = ScanPointGeneratorFactory.JCompoundGeneratorFactory();
 		
-        Object[] excluders = getExcluders(gen.getModel().getRegions());
+        Object[] excluders = {}; //getExcluders(gen.getModel().getRegions()); TODO put back in when excluders are fixed in Python
         Object[] mutators = getMutators(gen.getModel().getMutators());
         
         @SuppressWarnings("unchecked")

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/epics/PVDataSerializationTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/epics/PVDataSerializationTest.java
@@ -62,6 +62,7 @@ public class PVDataSerializationTest {
 		this.connectorService = new EpicsV4ConnectorService();
 	}
 	
+	@Ignore // TODO Un-Ignore when excluders are fixed in pythong
 	@Test
 	public void TestCircularROI() throws Exception {
 
@@ -133,6 +134,7 @@ public class PVDataSerializationTest {
 		assertEquals(expectedCompGenPVStructure.getSubField("excluders"), pvStructure.getSubField("excluders"));
 	}
 	
+	@Ignore // TODO Un-Ignore when excluders are fixed in pythong
 	@Test
 	public void TestEllipticalROI() throws Exception {
 
@@ -256,6 +258,7 @@ public class PVDataSerializationTest {
 		assertEquals(expectedCompGenPVStructure.getSubField("excluders"), pvStructure.getSubField("excluders"));
 	}
 	
+	@Ignore // TODO Un-Ignore when excluders are fixed in pythong
 	@Test
 	public void TestPointROI() throws Exception {
 
@@ -429,6 +432,7 @@ public class PVDataSerializationTest {
 		assertEquals(expectedCompGenPVStructure.getSubField("excluders"), pvStructure.getSubField("excluders"));
 	}
 	
+	@Ignore // TODO Un-Ignore when excluders are fixed in pythong
 	@Test
 	public void TestRectangularROI() throws Exception {
 
@@ -510,6 +514,7 @@ public class PVDataSerializationTest {
 		assertEquals(expectedCompGenPVStructure.getSubField("excluders"), pvStructure.getSubField("excluders"));
 	}
 	
+	@Ignore // TODO Un-Ignore when excluders are fixed in pythong
 	@Test
 	public void TestSectorROI() throws Exception {
 
@@ -1007,6 +1012,7 @@ public class PVDataSerializationTest {
 		assertEquals(expectedCompGenPVStructure, pvStructure);
 	}
 	
+	@Ignore // TODO Un-Ignore when excluders are fixed in pythong
 	@Test
 	public void TestFullCompoundGenerator() throws Exception {
 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/real/ExampleMalcolmDeviceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/real/ExampleMalcolmDeviceTest.java
@@ -322,8 +322,9 @@ public class ExampleMalcolmDeviceTest {
 			crUnionArray[0].set(expectedExcluder1PVStructure);
 			crUnionArray[1] = PVDataFactory.getPVDataCreate().createPVUnion(union);
 			crUnionArray[1].set(expectedExcluder2PVStructure);
-					
-			configurePVStructure.getUnionArrayField("generator.excluders").put(0, crUnionArray.length, crUnionArray, 0);
+				
+			// TODO Put back in when excluders are fixed in python
+			//configurePVStructure.getUnionArrayField("generator.excluders").put(0, crUnionArray.length, crUnionArray, 0);
 
 			assertEquals(configureStructure, configureCall.getStructure());
 			assertEquals(configurePVStructure, configureCall);


### PR DESCRIPTION
Until the python code for excluders is fixed, don't add excluders to
compound generators
http://jira.diamond.ac.uk/browse/DAQ-356