### PR TITLE
[DAQ-375] more fixes to get malcolm device working on i18 server

### DIFF
--- a/org.eclipse.scanning.api/META-INF/MANIFEST.MF
+++ b/org.eclipse.scanning.api/META-INF/MANIFEST.MF
@@ -40,4 +40,5 @@ Export-Package: org.eclipse.scanning.api,
  org.eclipse.scanning.api.script,
  org.eclipse.scanning.api.streams,
  org.eclipse.scanning.api.ui
+Import-Package: org.slf4j
 

--- a/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/AbstractMalcolmDevice.java
+++ b/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/AbstractMalcolmDevice.java
@@ -54,11 +54,14 @@ public abstract class AbstractMalcolmDevice<M extends IMalcolmModel> extends Abs
 	// Connection to serialization to talk to the remote object
 	protected MessageGenerator<MalcolmMessage> connectionDelegate;
 	
+	protected IMalcolmConnectorService<MalcolmMessage> connector;
+	
 	private IPointGenerator<?> pointGenerator;
 	
 	public AbstractMalcolmDevice(IMalcolmConnectorService<MalcolmMessage> connector,
 			IRunnableDeviceService runnableDeviceService) throws MalcolmDeviceException {
 		super(runnableDeviceService);
+		this.connector = connector;
    		this.connectionDelegate = connector.createDeviceConnection(this);
    		this.eventDelegate = new MalcolmEventDelegate(getName(), connector);
    		setRole(DeviceRole.MALCOLM);

--- a/org.eclipse.scanning.points/src/org/eclipse/scanning/points/classregistry/ScanningAPIClassRegistry.java
+++ b/org.eclipse.scanning.points/src/org/eclipse/scanning/points/classregistry/ScanningAPIClassRegistry.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.eclipse.dawnsci.analysis.api.persistence.IClassRegistry;
 import org.eclipse.scanning.api.device.models.ClusterProcessingModel;
+import org.eclipse.scanning.api.device.models.MalcolmModel;
 import org.eclipse.scanning.api.device.models.ProcessingModel;
 import org.eclipse.scanning.api.event.alive.HeartbeatBean;
 import org.eclipse.scanning.api.event.alive.KillBean;
@@ -141,6 +142,8 @@ public class ScanningAPIClassRegistry implements IClassRegistry {
 		registerClass(tmp, TaskBean.class);
 		
 		// malcolm.event
+		registerClass(tmp, MalcolmModel.class);
+		registerClass(tmp, Float.class);
 		registerClass(tmp, MalcolmEventBean.class);
 		registerClass(tmp, MalcolmTable.class);
 		registerClass(tmp, ChoiceAttribute.class);


### PR DESCRIPTION
Moving initialization of MalcolmDevice out of constructor and into an initialize method that is called when register is invoked.
Adding MalcolmModel and Float to ScanningAPIClassRegister for JSON serialization