### PR TITLE
Update JRebel config

### DIFF
--- a/org.eclipse.scanning.api/src/rebel.xml
+++ b/org.eclipse.scanning.api/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.api/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.api/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.command/src/rebel.xml
+++ b/org.eclipse.scanning.command/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.command/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.command/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.connector.epics/src/rebel.xml
+++ b/org.eclipse.scanning.connector.epics/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.connector.epics/target/classes">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.connector.epics/target/classes">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.connector.epicsv3/src/rebel.xml
+++ b/org.eclipse.scanning.connector.epicsv3/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.connector.epicsv3/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.connector.epicsv3/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.device.ui/src/rebel.xml
+++ b/org.eclipse.scanning.device.ui/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.device.ui/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.device.ui/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.event.ui/src/rebel.xml
+++ b/org.eclipse.scanning.event.ui/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.event.ui/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.event.ui/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.event/src/rebel.xml
+++ b/org.eclipse.scanning.event/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.event/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.event/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.example/src/rebel.xml
+++ b/org.eclipse.scanning.example/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.example/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.example/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.malcolm.core/src/rebel.xml
+++ b/org.eclipse.scanning.malcolm.core/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.malcolm.core/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.malcolm.core/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.points/src/rebel.xml
+++ b/org.eclipse.scanning.points/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.points/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.points/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.sequencer/src/rebel.xml
+++ b/org.eclipse.scanning.sequencer/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.sequencer/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.sequencer/bin">
 		</dir>
 	</classpath>
 

--- a/org.eclipse.scanning.server/src/rebel.xml
+++ b/org.eclipse.scanning.server/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/org.eclipse.scanning.server/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/org.eclipse.scanning.server/bin">
 		</dir>
 	</classpath>
 

--- a/uk.ac.diamond.daq.activemq.connector/src/rebel.xml
+++ b/uk.ac.diamond.daq.activemq.connector/src/rebel.xml
@@ -2,7 +2,7 @@
 <application generated-by="eclipse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.zeroturnaround.com" xsi:schemaLocation="http://www.zeroturnaround.com http://update.zeroturnaround.com/jrebel/rebel-2_1.xsd">
 
 	<classpath>
-		<dir name="${rebel.workspace.path}_git/daq-eclipse.git/uk.ac.diamond.daq.activemq.connector/bin">
+		<dir name="${rebel.workspace.path}/../workspace_git/daq-eclipse.git/uk.ac.diamond.daq.activemq.connector/bin">
 		</dir>
 	</classpath>
 


### PR DESCRIPTION
The JRebel plugin assumes you will have a forward slash after the 
expanded version of ${rebel.workspace.path} so you have to do it this 
way


Change-Id: I80b4920e2ecb3109cec31b88e0e32b84ff917005
Signed-off-by: Keith Ralphs <keith.ralphs@diamond.ac.uk>