### PR TITLE
Workaround for simultaneous Epics Channel Access.

### DIFF
--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/malcolm/DummyMalcolmDevice.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/malcolm/DummyMalcolmDevice.java
@@ -324,6 +324,8 @@ public class DummyMalcolmDevice extends AbstractMalcolmDevice<DummyMalcolmModel>
 	
 	private ScanInformation scanInformation = null; 
 	
+	private boolean paused = false;
+	
 	// the dummy devices are responsible for writing the nexus files 
 	private Map<String, IDummyMalcolmControlledDevice> devices = null;
 	
@@ -607,6 +609,7 @@ public class DummyMalcolmDevice extends AbstractMalcolmDevice<DummyMalcolmModel>
 	
 	@Override
 	public void run(IPosition outerScanPosition) throws ScanningException, InterruptedException {
+		paused = false;
 		setDeviceState(DeviceState.RUNNING);
 		status.setValue("Running");
 		completedSteps.setValue(totalSteps.getValue());
@@ -623,6 +626,9 @@ public class DummyMalcolmDevice extends AbstractMalcolmDevice<DummyMalcolmModel>
 		
 		// get each dummy device to write its position at each inner scan position
 		for (IPosition innerScanPosition : innerScanPositions) {
+			while (paused) {
+				Thread.sleep(1000);
+			}
 			final IPosition overallScanPosition = outerScanPosition.compound(innerScanPosition);
 			overallScanPosition.setStepIndex(stepIndex++);
 			for (IDummyMalcolmControlledDevice device : devices.values()) {
@@ -730,6 +736,16 @@ public class DummyMalcolmDevice extends AbstractMalcolmDevice<DummyMalcolmModel>
 		} catch (NoSuchMethodError | Exception ne) {
 			throw new ScanningException(ne);
 		}
+	}
+	
+	@Override
+	public void pause() throws ScanningException {
+		paused = true;
+	}
+	
+	@Override
+	public void resume() throws ScanningException {
+		paused = false;
 	}
 	
 	@Override


### PR DESCRIPTION
Clear the internal Epics transport cache so that a new connection is made for each call.
Added pause mechanism to DummyMalcolmDevice.

http://jira.diamond.ac.uk/browse/DAQ-218