### PR TITLE
Removed calls to EPICSV4 ClientFactory after recommendation from MRK

### DIFF
--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
@@ -59,7 +59,6 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
     
     public EpicsV4ConnectorService() {
 		mapper = new EpicsV4MessageMapper();
-		org.epics.pvaccess.ClientFactory.start();
 		this.listeners = new Hashtable<Long, Collection<EpicsV4MonitorListener>>(7);
 		pvaClient = PvaClient.get("pva");
 	}
@@ -71,7 +70,6 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
 
 	@Override
 	public void disconnect() throws MalcolmDeviceException {
-		org.epics.pvaccess.ClientFactory.stop();
         pvaClient.destroy();
 	}
 	


### PR DESCRIPTION
One of the developers for EPICS says that these calls are not needed
http://jira.diamond.ac.uk/browse/DAQ-218