### PR TITLE
Topup with higher order scans

### DIFF
--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/IDeviceController.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/IDeviceController.java
@@ -68,4 +68,9 @@ public interface IDeviceController {
 	 */
 	String getName();
 	
+	/**
+	 * 
+	 * @return true if the devices (watchdogs) in this contoller all think they are running in a scan.
+	 */
+	boolean isActive();
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/IDeviceWatchdog.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/device/IDeviceWatchdog.java
@@ -59,6 +59,12 @@ public interface IDeviceWatchdog extends IModelProvider<DeviceWatchdogModel> {
 	 */
 	void activate();
 	
+	/**
+	 * 
+	 * @return true if the watchdog is active in a scan and checking things.
+	 */
+	boolean isActive();
+
     /**
 	 * Make this device inactive
 	 */
@@ -80,4 +86,5 @@ public interface IDeviceWatchdog extends IModelProvider<DeviceWatchdogModel> {
 	 * @param model
 	 */
 	void setModel(DeviceWatchdogModel model);
+
 }

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/IMalcolmDevice.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/malcolm/IMalcolmDevice.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 import org.eclipse.scanning.api.IValidator;
 import org.eclipse.scanning.api.device.IRunnableEventDevice;
-import org.eclipse.scanning.api.points.IPointGenerator;
 
 
 /**
@@ -54,18 +53,6 @@ public interface IMalcolmDevice<T> extends IRunnableEventDevice<T>, IMalcolmEven
 	 * @return true if not in locked state, otherwise false.
 	 */
 	public boolean isLocked() throws MalcolmDeviceException ;
-	
-	/**
-	 * Set the point generator for the malcolm device.
-	 * @param pointGenerator point generator
-	 */
-	public void setPointGenerator(IPointGenerator<?> pointGenerator);
-	
-	/**
-	 * Get the point generator for the malcolm device
-	 * @return point generator
-	 */
-	public IPointGenerator<?> getPointGenerator();
 	
 	/**
 	 * Gets the value of an attribute on the device

--- a/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/models/StepModel.java
+++ b/org.eclipse.scanning.api/src/org/eclipse/scanning/api/points/models/StepModel.java
@@ -8,16 +8,16 @@ import org.eclipse.scanning.api.annotation.ui.FieldDescriptor;
  */
 public class StepModel extends AbstractPointsModel {
 
-	@FieldDescriptor(label="Device", device=DeviceType.SCANNABLE)
+	@FieldDescriptor(label="Device", device=DeviceType.SCANNABLE, fieldPosition=0)
 	private String name;
 	
-	@FieldDescriptor(label="Start", scannable="name", hint="This is the start position for the scan") // The scannable lookup gets the units
+	@FieldDescriptor(label="Start", scannable="name", hint="This is the start position for the scan", fieldPosition=1) // The scannable lookup gets the units
 	private double start;
 	
-	@FieldDescriptor(label="Stop", scannable="name", hint="This is the stop position for the scan") // The scannable lookup gets the units
+	@FieldDescriptor(label="Stop", scannable="name", hint="This is the stop position for the scan", fieldPosition=2) // The scannable lookup gets the units
 	private double stop;
 	
-	@FieldDescriptor(label="Step", scannable="name", hint="This is the step during the scan") // The scannable lookup gets the units
+	@FieldDescriptor(label="Step", scannable="name", hint="This is the step during the scan", fieldPosition=3) // The scannable lookup gets the units
 	private double step;
 	
 	public StepModel() {

--- a/org.eclipse.scanning.example/src/org/eclipse/scanning/example/malcolm/DummyMalcolmDevice.java
+++ b/org.eclipse.scanning.example/src/org/eclipse/scanning/example/malcolm/DummyMalcolmDevice.java
@@ -531,9 +531,12 @@ public class DummyMalcolmDevice extends AbstractMalcolmDevice<DummyMalcolmModel>
 	public void setPointGenerator(IPointGenerator<?> pointGenerator) {
 		super.setPointGenerator(pointGenerator);
 		
-		scanRank = pointGenerator.iterator().next().getScanRank();
-		if (scanRank < 0) {
-			scanRank = 1;
+		if (pointGenerator!=null) { // Some tests end up using the configure call of 
+			                        // RunnableDeviceService which does not have a pointGenerator
+			scanRank = pointGenerator.iterator().next().getScanRank();
+			if (scanRank < 0) {
+				scanRank = 1;
+			}
 		}
 	}
 	

--- a/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/AbstractMalcolmDevice.java
+++ b/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/AbstractMalcolmDevice.java
@@ -10,6 +10,7 @@ import org.eclipse.dawnsci.nexus.IMultipleNexusDevice;
 import org.eclipse.dawnsci.nexus.NexusException;
 import org.eclipse.dawnsci.nexus.NexusScanInfo;
 import org.eclipse.dawnsci.nexus.builder.NexusObjectProvider;
+import org.eclipse.scanning.api.annotation.scan.PreConfigure;
 import org.eclipse.scanning.api.device.AbstractRunnableDevice;
 import org.eclipse.scanning.api.device.IRunnableDeviceService;
 import org.eclipse.scanning.api.device.models.DeviceRole;
@@ -56,7 +57,7 @@ public abstract class AbstractMalcolmDevice<M extends IMalcolmModel> extends Abs
 	
 	protected IMalcolmConnectorService<MalcolmMessage> connector;
 	
-	private IPointGenerator<?> pointGenerator;
+	protected IPointGenerator<?> pointGenerator;
 	
 	public AbstractMalcolmDevice(IMalcolmConnectorService<MalcolmMessage> connector,
 			IRunnableDeviceService runnableDeviceService) throws MalcolmDeviceException {
@@ -67,6 +68,14 @@ public abstract class AbstractMalcolmDevice<M extends IMalcolmModel> extends Abs
    		setRole(DeviceRole.MALCOLM);
 	}
 		
+	@PreConfigure
+	public void setPointGenerator(IPointGenerator<?> pointGenerator) {
+		this.pointGenerator = pointGenerator;
+	}
+	public IPointGenerator<?> getPointGenerator() {
+		return pointGenerator;
+	}
+	
 	/**
 	 * Enacts any pre-actions or conditions before the device attempts to run the task block.
 	 *  
@@ -87,16 +96,6 @@ public abstract class AbstractMalcolmDevice<M extends IMalcolmModel> extends Abs
 	
 	protected void setTemplateBean(MalcolmEventBean bean) {
 		eventDelegate.setTemplateBean(bean);
-	}
-	
-	@Override
-	public void setPointGenerator(IPointGenerator<?> pointGenerator) {
-		this.pointGenerator = pointGenerator;
-	}
-	
-	@Override
-	public IPointGenerator<?> getPointGenerator() {
-		return pointGenerator;
 	}
 
 	public void start(final IPosition pos) throws ScanningException, InterruptedException {

--- a/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/MalcolmDevice.java
+++ b/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/MalcolmDevice.java
@@ -351,7 +351,7 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 
 	private EpicsMalcolmModel createEpicsMalcolmModel(M model) {
 		double exposureTime = model.getExposureTime();
-		IPointGenerator<?> pointGenerator = getPointGenerator();
+
 		if (pointGenerator != null) { // TODO could the point generator be null here?
 			List<IMutator> mutators = Arrays.asList(new FixedDurationMutator(exposureTime));
 			((CompoundModel<?>) pointGenerator.getModel()).setMutators(mutators);

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/watchdog/AbstractWatchdog.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/watchdog/AbstractWatchdog.java
@@ -3,6 +3,8 @@ package org.eclipse.scanning.sequencer.watchdog;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.scanning.api.IScannable;
+import org.eclipse.scanning.api.annotation.scan.ScanFinally;
+import org.eclipse.scanning.api.annotation.scan.ScanStart;
 import org.eclipse.scanning.api.device.IDeviceController;
 import org.eclipse.scanning.api.device.IDeviceWatchdog;
 import org.eclipse.scanning.api.device.IScannableDeviceService;
@@ -15,6 +17,7 @@ public abstract class AbstractWatchdog implements IDeviceWatchdog {
 	
 	protected DeviceWatchdogModel model;
 	protected IDeviceController  controller;
+	protected boolean active = false;
 
 	public AbstractWatchdog() {
 		this(null);
@@ -92,4 +95,18 @@ public abstract class AbstractWatchdog implements IDeviceWatchdog {
 		this.controller = controller;
 	}
 
+	@ScanStart
+	public void scanStarted() {
+		active = true;
+	}
+	
+	@ScanFinally
+	public void scanFinally() {
+		active = false;
+	}
+	
+	@Override
+	public boolean isActive() {
+		return active;
+	}
 }

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/watchdog/DeviceController.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/watchdog/DeviceController.java
@@ -4,9 +4,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.eclipse.scanning.api.device.IDeviceController;
+import org.eclipse.scanning.api.device.IDeviceWatchdog;
 import org.eclipse.scanning.api.device.IPausableDevice;
 import org.eclipse.scanning.api.device.models.DeviceWatchdogModel;
 import org.eclipse.scanning.api.event.scan.DeviceState;
@@ -127,6 +127,14 @@ class DeviceController implements IDeviceController {
 
 	public void setObjects(List<?> objects) {
 		this.objects = objects;
+	}
+	
+	public boolean isActive() {
+		boolean is = true;
+		for (Object object : objects) {
+			if (object instanceof IDeviceWatchdog) is = is && ((IDeviceWatchdog)object).isActive();
+		}
+		return is;
 	}
 
 	@Override

--- a/org.eclipse.scanning.server/src/org/eclipse/scanning/server/servlet/ScanProcess.java
+++ b/org.eclipse.scanning.server/src/org/eclipse/scanning/server/servlet/ScanProcess.java
@@ -23,7 +23,6 @@ import org.eclipse.scanning.api.event.scan.DeviceInformation;
 import org.eclipse.scanning.api.event.scan.ScanBean;
 import org.eclipse.scanning.api.event.scan.ScanRequest;
 import org.eclipse.scanning.api.event.status.Status;
-import org.eclipse.scanning.api.malcolm.IMalcolmDevice;
 import org.eclipse.scanning.api.points.GeneratorException;
 import org.eclipse.scanning.api.points.IDeviceDependentIterable;
 import org.eclipse.scanning.api.points.IPointGenerator;
@@ -256,10 +255,6 @@ public class ScanProcess implements IConsumerProcess<ScanBean> {
 		malcolmModel.setFileDir(malcolmOutputDir.toString());
 		logger.info("Set malcolm output dir to {}", malcolmOutputDir);
 		
-		// Set the point generator for the malcolm device
-		final IRunnableDeviceService service = Services.getRunnableDeviceService();
-		IRunnableDevice<?> malcolmDevice = service.getRunnableDevice(malcolmDeviceName);
-		((IMalcolmDevice<?>) malcolmDevice).setPointGenerator(gen);
 	}
 
 	private ScriptResponse<?> runScript(ScriptRequest req) throws EventException, UnsupportedLanguageException, ScriptExecutionException {
@@ -321,12 +316,9 @@ public class ScanProcess implements IConsumerProcess<ScanBean> {
 			@SuppressWarnings("unchecked")
 			IRunnableDevice<Object> odevice = (IRunnableDevice<Object>)device;
 			Object dmodel = dmodels.get(odevice.getName());
-			if (odevice instanceof IMalcolmDevice<?>) {
-				((IMalcolmDevice<?>) odevice).setPointGenerator(generator);
-			}
-			manager.invoke(PreConfigure.class, dmodel);
+			manager.invoke(PreConfigure.class, dmodel, generator);
 			odevice.configure(dmodel);
-			manager.invoke(PostConfigure.class, dmodel);
+			manager.invoke(PostConfigure.class, dmodel, generator);
 		}
 	}
 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/real/ExampleMalcolmDeviceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/malcolm/real/ExampleMalcolmDeviceTest.java
@@ -23,6 +23,7 @@ import org.eclipse.scanning.api.points.models.SpiralModel;
 import org.eclipse.scanning.connector.epics.EpicsV4ConnectorService;
 import org.eclipse.scanning.example.malcolm.ExampleMalcolmDevice;
 import org.eclipse.scanning.example.malcolm.ExampleMalcolmModel;
+import org.eclipse.scanning.malcolm.core.AbstractMalcolmDevice;
 import org.eclipse.scanning.malcolm.core.MalcolmService;
 import org.eclipse.scanning.points.PointGeneratorService;
 import org.epics.pvdata.factory.FieldFactory;
@@ -83,7 +84,8 @@ public class ExampleMalcolmDeviceTest {
 			pmac1.setFileDir("/TestFile/Dir");
 
 			// Set the generator on the device
-			modelledDevice.setPointGenerator(scan);
+			// Cannot set the generator from @PreConfigure in this unit test.
+			((AbstractMalcolmDevice)modelledDevice).setPointGenerator(scan);
 			
 			// Call configure
 			modelledDevice.configure(pmac1);

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AbstractWatchdogTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AbstractWatchdogTest.java
@@ -18,7 +18,10 @@ import org.eclipse.scanning.api.points.IPointGenerator;
 import org.eclipse.scanning.api.points.IPointGeneratorService;
 import org.eclipse.scanning.api.points.IPosition;
 import org.eclipse.scanning.api.points.models.BoundingBox;
+import org.eclipse.scanning.api.points.models.CompoundModel;
 import org.eclipse.scanning.api.points.models.GridModel;
+import org.eclipse.scanning.api.points.models.IScanPathModel;
+import org.eclipse.scanning.api.points.models.StepModel;
 import org.eclipse.scanning.api.scan.ScanningException;
 import org.eclipse.scanning.api.scan.event.IRunListener;
 import org.eclipse.scanning.api.scan.event.RunEvent;
@@ -105,15 +108,25 @@ public abstract class AbstractWatchdogTest {
 		ServiceHolder.setWatchdogService(null);
 	}
 
-	
 	protected IDeviceController createTestScanner(IScannable<?> monitor) throws Exception {
+		return createTestScanner(monitor, 2);
+	}
+	protected IDeviceController createTestScanner(IScannable<?> monitor, int dims) throws Exception {
 		
+		List<IScanPathModel> models = new ArrayList<>();
+		if (dims>2) {
+			for (int i = dims; i>2; i--) {
+				models.add(new StepModel("T"+i, 290, 292, 1));
+			}
+		}
 		// Create scan points for a grid and make a generator
 		GridModel gmodel = new GridModel("x", "y");
 		gmodel.setSlowAxisPoints(5);
 		gmodel.setFastAxisPoints(5);
 		gmodel.setBoundingBox(new BoundingBox(0,0,3,3));	
-		IPointGenerator<?> gen = gservice.createGenerator(gmodel);
+		models.add(gmodel);
+		
+		IPointGenerator<?> gen = gservice.createCompoundGenerator(new CompoundModel<>(models));
 
 		// Create the model for a scan.
 		final ScanModel  smodel = new ScanModel();

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AbstractWatchdogTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/AbstractWatchdogTest.java
@@ -1,11 +1,21 @@
 package org.eclipse.scanning.test.scan;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
+import org.eclipse.dawnsci.hdf5.nexus.NexusFileFactoryHDF5;
 import org.eclipse.dawnsci.json.MarshallerService;
+import org.eclipse.dawnsci.nexus.builder.impl.DefaultNexusBuilderFactory;
+import org.eclipse.dawnsci.remotedataset.test.mock.LoaderServiceMock;
 import org.eclipse.scanning.api.IScannable;
+import org.eclipse.scanning.api.annotation.scan.AnnotationManager;
+import org.eclipse.scanning.api.annotation.scan.PostConfigure;
+import org.eclipse.scanning.api.annotation.scan.PreConfigure;
 import org.eclipse.scanning.api.device.IDeviceController;
 import org.eclipse.scanning.api.device.IDeviceWatchdogService;
 import org.eclipse.scanning.api.device.IPausableDevice;
@@ -22,19 +32,25 @@ import org.eclipse.scanning.api.points.models.CompoundModel;
 import org.eclipse.scanning.api.points.models.GridModel;
 import org.eclipse.scanning.api.points.models.IScanPathModel;
 import org.eclipse.scanning.api.points.models.StepModel;
+import org.eclipse.scanning.api.scan.ScanEstimator;
+import org.eclipse.scanning.api.scan.ScanInformation;
 import org.eclipse.scanning.api.scan.ScanningException;
 import org.eclipse.scanning.api.scan.event.IRunListener;
 import org.eclipse.scanning.api.scan.event.RunEvent;
 import org.eclipse.scanning.api.scan.models.ScanModel;
 import org.eclipse.scanning.event.EventServiceImpl;
 import org.eclipse.scanning.example.classregistry.ScanningExampleClassRegistry;
+import org.eclipse.scanning.example.malcolm.DummyMalcolmDevice;
+import org.eclipse.scanning.example.malcolm.DummyMalcolmModel;
 import org.eclipse.scanning.example.scannable.MockScannableConnector;
+import org.eclipse.scanning.malcolm.core.AbstractMalcolmDevice;
 import org.eclipse.scanning.points.PointGeneratorService;
 import org.eclipse.scanning.points.classregistry.ScanningAPIClassRegistry;
 import org.eclipse.scanning.points.serialization.PointsModelMarshaller;
 import org.eclipse.scanning.sequencer.RunnableDeviceServiceImpl;
 import org.eclipse.scanning.sequencer.ServiceHolder;
 import org.eclipse.scanning.sequencer.watchdog.DeviceWatchdogService;
+import org.eclipse.scanning.server.application.Activator;
 import org.eclipse.scanning.server.servlet.Services;
 import org.eclipse.scanning.test.ScanningTestClassRegistry;
 import org.eclipse.scanning.test.scan.mock.MockDetectorModel;
@@ -76,6 +92,7 @@ public abstract class AbstractWatchdogTest {
 		RunnableDeviceServiceImpl impl = (RunnableDeviceServiceImpl)sservice;
 		impl._register(MockDetectorModel.class, MockWritableDetector.class);
 		impl._register(MockWritingMandlebrotModel.class, MockWritingMandelbrotDetector.class);
+		impl._register(DummyMalcolmModel.class, DummyMalcolmDevice.class);
 		ServiceHolder.setRunnableDeviceService(sservice);
 
 		gservice  = new PointGeneratorService();
@@ -97,6 +114,19 @@ public abstract class AbstractWatchdogTest {
 		IDeviceWatchdogService wservice = new DeviceWatchdogService();
 		ServiceHolder.setWatchdogService(wservice);
 		Services.setWatchdogService(wservice);
+	
+		// Provide lots of services that OSGi would normally.
+		Services.setEventService(eservice);
+		Services.setRunnableDeviceService(sservice);
+		Services.setGeneratorService(gservice);
+		Services.setConnector(connector);
+		org.eclipse.scanning.example.Services.setPointGeneratorService(gservice);
+		org.eclipse.scanning.example.Services.setEventService(eservice);
+		org.eclipse.scanning.example.Services.setRunnableDeviceService(sservice);
+		org.eclipse.scanning.example.Services.setScannableDeviceService(connector);
+		
+		ServiceHolder.setTestServices(new LoaderServiceMock(), new DefaultNexusBuilderFactory(), null, null, gservice);
+		org.eclipse.dawnsci.nexus.ServiceHolder.setNexusFileFactory(new NexusFileFactoryHDF5());
 
 		createWatchdogs();
 	}
@@ -109,9 +139,10 @@ public abstract class AbstractWatchdogTest {
 	}
 
 	protected IDeviceController createTestScanner(IScannable<?> monitor) throws Exception {
-		return createTestScanner(monitor, 2);
+		return createTestScanner(monitor, null, null, 2);
 	}
-	protected IDeviceController createTestScanner(IScannable<?> monitor, int dims) throws Exception {
+	
+	protected <T> IDeviceController createTestScanner(IScannable<?> monitor, IRunnableDevice<T> device, T dmodel, int dims) throws Exception {
 		
 		List<IScanPathModel> models = new ArrayList<>();
 		if (dims>2) {
@@ -127,11 +158,30 @@ public abstract class AbstractWatchdogTest {
 		models.add(gmodel);
 		
 		IPointGenerator<?> gen = gservice.createCompoundGenerator(new CompoundModel<>(models));
+		
+		if (dmodel!=null) {
+			AnnotationManager manager = new AnnotationManager(Activator.createResolver());
+			manager.addDevices(device);
+			manager.addContext(new ScanInformation(new ScanEstimator(gen, (Map<String, Object>)null, 1)));
+			
+			manager.invoke(PreConfigure.class, dmodel, gen);
+			if (device instanceof AbstractMalcolmDevice) {
+				assertNotNull(((AbstractMalcolmDevice)device).getPointGenerator());
+			}
+			
+			device.configure(dmodel);
+			assertNotNull(device.getModel());
+			assertEquals(dmodel, device.getModel());
+			
+			manager.invoke(PostConfigure.class, dmodel, gen);
+		}
 
 		// Create the model for a scan.
 		final ScanModel  smodel = new ScanModel();
 		smodel.setPositionIterable(gen);
-		smodel.setDetectors(detector);
+		
+		if (device==null) device = (IRunnableDevice<T>)detector;
+		smodel.setDetectors(device);
 		if (monitor!=null) smodel.setMonitors(monitor);
 		
 		// Create a scan and run it without publishing events

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogTopupTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogTopupTest.java
@@ -27,6 +27,7 @@ import org.eclipse.scanning.example.scannable.MockScannable;
 import org.eclipse.scanning.example.scannable.MockTopupScannable;
 import org.eclipse.scanning.sequencer.watchdog.TopupWatchdog;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class WatchdogTopupTest extends AbstractWatchdogTest {
@@ -117,15 +118,30 @@ public class WatchdogTopupTest extends AbstractWatchdogTest {
 	}
 	
 	@Test
-	public void topupInScan() throws Exception {
-
+	public void topupIn2DScan() throws Exception {
+        topupInScan(2);
+	}
+	
+	@Test
+	public void topupIn3DScan() throws Exception {
+        topupInScan(3);
+	}
+	
+	@Ignore("Needs to work and does but takes a long time so not part of main tests.")
+	@Test
+	public void topupIn5DScan() throws Exception {
+        topupInScan(5);
+	}
+	
+	private void topupInScan(int size) throws Exception {
+		
 		final IScannable<Number>   topups  = connector.getScannable("topup");
 		final MockTopupScannable   topup   = (MockTopupScannable)topups;
 		assertNotNull(topup);
         topup.start();
 		
 		// x and y are level 3
-		IDeviceController controller = createTestScanner(null);
+		IDeviceController controller = createTestScanner(null, size);
 		IRunnableEventDevice<?> scanner = (IRunnableEventDevice<?>)controller.getDevice();
 		
 		Set<DeviceState> states = new HashSet<>();
@@ -142,7 +158,7 @@ public class WatchdogTopupTest extends AbstractWatchdogTest {
 		assertTrue(states.contains(DeviceState.RUNNING));
 		assertTrue(states.contains(DeviceState.SEEKING));
 	}
-	
+
 	@Test
 	public void scanDuringTopup() throws Exception {
 

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogTopupTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/WatchdogTopupTest.java
@@ -6,7 +6,11 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -14,6 +18,7 @@ import java.util.Set;
 import org.eclipse.scanning.api.IScannable;
 import org.eclipse.scanning.api.device.IDeviceController;
 import org.eclipse.scanning.api.device.IDeviceWatchdog;
+import org.eclipse.scanning.api.device.IRunnableDevice;
 import org.eclipse.scanning.api.device.IRunnableEventDevice;
 import org.eclipse.scanning.api.device.models.DeviceWatchdogModel;
 import org.eclipse.scanning.api.event.scan.DeviceState;
@@ -23,18 +28,25 @@ import org.eclipse.scanning.api.scan.event.IPositionListenable;
 import org.eclipse.scanning.api.scan.event.IPositionListener;
 import org.eclipse.scanning.api.scan.event.IRunListener;
 import org.eclipse.scanning.api.scan.event.RunEvent;
+import org.eclipse.scanning.example.malcolm.DummyMalcolmModel;
 import org.eclipse.scanning.example.scannable.MockScannable;
 import org.eclipse.scanning.example.scannable.MockTopupScannable;
 import org.eclipse.scanning.sequencer.watchdog.TopupWatchdog;
+import org.eclipse.scanning.test.messaging.FileUtils;
+import org.eclipse.scanning.test.scan.nexus.DummyMalcolmDeviceTest;
 import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WatchdogTopupTest extends AbstractWatchdogTest {
 
 	
-	
 	private IDeviceWatchdog dog;
+	private File dir;
 		
 	void createWatchdogs() throws Exception {
 
@@ -55,13 +67,23 @@ public class WatchdogTopupTest extends AbstractWatchdogTest {
 		dog.activate();
 	}
 	
+	@Before
+	public void createDir() throws IOException{
+		this.dir = Files.createTempDirectory(DummyMalcolmDeviceTest.class.getSimpleName()).toFile();
+		dir.deleteOnExit();
+	}
+	
 	@After
 	public void disconnect() throws Exception {
+		
 		final IScannable<Number>   topups  = connector.getScannable("topup");
 		final MockTopupScannable   topup   = (MockTopupScannable)topups;
 		assertNotNull(topup);
 		topup.disconnect();
 		topup.setPosition(1000);
+		
+		FileUtils.recursiveDelete(dir);
+
 	}
 	
 	@Test(expected=Exception.class)
@@ -133,7 +155,54 @@ public class WatchdogTopupTest extends AbstractWatchdogTest {
         topupInScan(5);
 	}
 	
+	@Test
+	public void topupIn2DScanMalcolm() throws Exception {
+		
+		DummyMalcolmModel model = createModel();
+		IRunnableDevice<DummyMalcolmModel> malcolmDevice = sservice.createRunnableDevice(model, false);
+      
+		topupInScan(malcolmDevice, model, 2);		
+	}
+	
+	@Test
+	public void topupIn3DScanMalcolm() throws Exception {
+		
+		DummyMalcolmModel model = createModel();
+		IRunnableDevice<DummyMalcolmModel> malcolmDevice = sservice.createRunnableDevice(model, false);
+      
+		topupInScan(malcolmDevice, model, 3);
+	}
+	
+	@Test
+	public void topupSeveralMalcolm() throws Exception {
+		
+		DummyMalcolmModel model = createModel();
+		IRunnableDevice<DummyMalcolmModel> malcolmDevice = sservice.createRunnableDevice(model, false);
+      
+		topupInScan(malcolmDevice, model, 2);
+		
+		// We do another one to see if 2 in a row are the problem
+		topupInScan(malcolmDevice, model, 3);
+
+		// We do another one to see if 3 in a row are the problem
+		topupInScan(malcolmDevice, model, 3);
+	}
+
+
+	private DummyMalcolmModel createModel() throws IOException {
+		
+		DummyMalcolmModel model = DummyMalcolmDeviceTest.createModel(dir);
+		model.setExposureTime(0.05);
+		model.setAxesToMove(Arrays.asList("x", "y"));
+		assertNotNull(model.getFileDir());
+		return model;
+	}
+
 	private void topupInScan(int size) throws Exception {
+		topupInScan(null, null, size);
+	}
+
+	private <T> void topupInScan(IRunnableDevice<T> device, T detectorModel, int size) throws Exception {
 		
 		final IScannable<Number>   topups  = connector.getScannable("topup");
 		final MockTopupScannable   topup   = (MockTopupScannable)topups;
@@ -141,7 +210,7 @@ public class WatchdogTopupTest extends AbstractWatchdogTest {
         topup.start();
 		
 		// x and y are level 3
-		IDeviceController controller = createTestScanner(null, size);
+		IDeviceController controller = createTestScanner(null, device, detectorModel, size);
 		IRunnableEventDevice<?> scanner = (IRunnableEventDevice<?>)controller.getDevice();
 		
 		Set<DeviceState> states = new HashSet<>();
@@ -152,11 +221,12 @@ public class WatchdogTopupTest extends AbstractWatchdogTest {
 			}
 		});
 		
-		scanner.run(null);
+		scanner.run(null);				
+		assertTrue(!controller.isActive());
 		
-		assertTrue(states.contains(DeviceState.PAUSED));
-		assertTrue(states.contains(DeviceState.RUNNING));
-		assertTrue(states.contains(DeviceState.SEEKING));
+		assertTrue("States contain no paused: "+states,  states.contains(DeviceState.PAUSED));
+		assertTrue("States contain no running: "+states, states.contains(DeviceState.RUNNING));
+		assertTrue("States contain no seeking: "+states, states.contains(DeviceState.SEEKING));
 	}
 
 	@Test

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/nexus/DummyMalcolmDeviceTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/nexus/DummyMalcolmDeviceTest.java
@@ -66,6 +66,7 @@ public class DummyMalcolmDeviceTest extends NexusTest {
 	public void setUp() throws Exception {
 		// create a temp directory for the dummy malcolm device to write hdf files into
 		malcolmOutputDir = Files.createTempDirectory(DummyMalcolmDeviceTest.class.getSimpleName()).toFile();
+		malcolmOutputDir.deleteOnExit();
 	}
 
 	@After
@@ -110,9 +111,9 @@ public class DummyMalcolmDeviceTest extends NexusTest {
 		return gen;
 	}
 
-	private DummyMalcolmModel createModel() {
+	public static DummyMalcolmModel createModel(File dir) {
 		DummyMalcolmModel model = new DummyMalcolmModel();
-		model.setFileDir(malcolmOutputDir.getAbsolutePath());
+		model.setFileDir(dir.getAbsolutePath());
 
 		DummyMalcolmControlledDetectorModel det1Model = new DummyMalcolmControlledDetectorModel();
 		det1Model.setName("detector");
@@ -132,9 +133,10 @@ public class DummyMalcolmDeviceTest extends NexusTest {
 	
 	@Test
 	public void testDummyMalcolmNexusFiles() throws Exception {
-		DummyMalcolmModel model = createModel();
+		DummyMalcolmModel model = createModel(malcolmOutputDir);
 		IRunnableDevice<DummyMalcolmModel> malcolmDevice = dservice.createRunnableDevice(model, false);
-		((IMalcolmDevice<DummyMalcolmModel>) malcolmDevice).setPointGenerator(getGenerator(2, 2)); // Generator isn't actually used by the test malcolm device
+		// Cannot set the generator from @PreConfigure in this unit test.
+		((AbstractMalcolmDevice)malcolmDevice).setPointGenerator(getGenerator(2, 2));// Generator isn't actually used by the test malcolm device
 		int scanRank = 2;
 		assertNotNull(malcolmDevice);
 		malcolmDevice.configure(model);
@@ -147,10 +149,11 @@ public class DummyMalcolmDeviceTest extends NexusTest {
 	
 	@Test
 	public void testMalcolmNexusObjects() throws Exception {
-		DummyMalcolmModel model = createModel();
+		DummyMalcolmModel model = createModel(malcolmOutputDir);
 		IRunnableDevice<DummyMalcolmModel> malcolmDevice = dservice.createRunnableDevice(model, false);
 		int scanRank = 3;
-		((IMalcolmDevice<DummyMalcolmModel>) malcolmDevice).setPointGenerator(getGenerator(2, 2, 2));
+		// Cannot set the generator from @PreConfigure in this unit test.
+		((AbstractMalcolmDevice)malcolmDevice).setPointGenerator(getGenerator(2, 2, 2));// Generator isn't actually used by the test malcolm device
 		malcolmDevice.configure(model);
 
 		NexusScanInfo nexusScanInfo = new NexusScanInfo();

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/nexus/MalcolmScanTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/scan/nexus/MalcolmScanTest.java
@@ -355,7 +355,8 @@ public class MalcolmScanTest extends NexusTest {
 		final ScanModel smodel = new ScanModel();
 		smodel.setPositionIterable(gen);
 		smodel.setDetectors(malcolmDevice);
-		((IMalcolmDevice<?>) malcolmDevice).setPointGenerator(gen);
+		// Cannot set the generator from @PreConfigure in this unit test.
+		((AbstractMalcolmDevice)malcolmDevice).setPointGenerator(gen);
 		
 		// Create a file to scan into.
 		smodel.setFilePath(file.getAbsolutePath());

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/validation/AbstractValidationTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/validation/AbstractValidationTest.java
@@ -6,7 +6,6 @@ import org.eclipse.scanning.api.device.IRunnableDevice;
 import org.eclipse.scanning.api.device.IRunnableDeviceService;
 import org.eclipse.scanning.api.device.models.ClusterProcessingModel;
 import org.eclipse.scanning.api.device.models.ProcessingModel;
-import org.eclipse.scanning.api.malcolm.IMalcolmDevice;
 import org.eclipse.scanning.api.points.IPointGeneratorService;
 import org.eclipse.scanning.api.points.models.BoundingBox;
 import org.eclipse.scanning.api.points.models.GridModel;
@@ -19,6 +18,7 @@ import org.eclipse.scanning.example.detector.MandelbrotModel;
 import org.eclipse.scanning.example.malcolm.DummyMalcolmDevice;
 import org.eclipse.scanning.example.malcolm.DummyMalcolmModel;
 import org.eclipse.scanning.example.scannable.MockScannableConnector;
+import org.eclipse.scanning.malcolm.core.AbstractMalcolmDevice;
 import org.eclipse.scanning.points.PointGeneratorService;
 import org.eclipse.scanning.points.validation.ValidatorService;
 import org.eclipse.scanning.sequencer.RunnableDeviceServiceImpl;
@@ -72,10 +72,11 @@ public abstract class AbstractValidationTest {
 		device.getModel().setFileDir(dir.getAbsolutePath());
 		
 		// Just for testing, we make the detector legal.
-		IMalcolmDevice<?> mdevice = (IMalcolmDevice<?>)device;
+		AbstractMalcolmDevice<?> mdevice = (AbstractMalcolmDevice<?>)device;
 		GridModel gmodel = new GridModel("stage_x", "stage_y");
 		gmodel.setBoundingBox(new BoundingBox(10, -10, 100, -100));
-    	mdevice.setPointGenerator(pservice.createGenerator(gmodel));
+		// Cannot set the generator from @PreConfigure in this unit test.
+     	mdevice.setPointGenerator(pservice.createGenerator(gmodel));
 		
 
 	}


### PR DESCRIPTION
This change creates new tests for:
1. Topup in higher order scans,
2. Topup with malcolm devices
3. Topup with both

It also removes a special method in the malcolm interface because the annotation system provides this information. This then means that no casting and calls of a special method are needed.