### PR TITLE
Fix problems when Malcolm Devices are unavailable

### DIFF
--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
@@ -47,7 +47,7 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
 
 	static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-    static final double REQUEST_TIMEOUT = 1;
+    static final double REQUEST_TIMEOUT = 0.5;
 	
 	private static final Logger logger = LoggerFactory.getLogger(EpicsV4ConnectorService.class);
 	

--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
@@ -47,7 +47,7 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
 
 	static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-    static final double REQUEST_TIMEOUT = 0.1;
+    static final double REQUEST_TIMEOUT = 0.25;
 	
 	private static final Logger logger = LoggerFactory.getLogger(EpicsV4ConnectorService.class);
 	

--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
@@ -47,7 +47,7 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
 
 	static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-    static final double REQUEST_TIMEOUT = 0.5;
+    static final double REQUEST_TIMEOUT = 0.1;
 	
 	private static final Logger logger = LoggerFactory.getLogger(EpicsV4ConnectorService.class);
 	

--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
@@ -47,7 +47,7 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
 
 	static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-    static final double REQUEST_TIMEOUT = 0.1;
+    static final double REQUEST_TIMEOUT = 0.2;
 	
 	private static final Logger logger = LoggerFactory.getLogger(EpicsV4ConnectorService.class);
 	

--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
@@ -47,7 +47,7 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
 
 	static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-    static final double REQUEST_TIMEOUT = 3.0;
+    static final double REQUEST_TIMEOUT = 0.1;
 	
 	private static final Logger logger = LoggerFactory.getLogger(EpicsV4ConnectorService.class);
 	

--- a/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
+++ b/org.eclipse.scanning.connector.epics/src/org/eclipse/scanning/connector/epics/EpicsV4ConnectorService.java
@@ -47,7 +47,7 @@ public class EpicsV4ConnectorService implements IMalcolmConnectorService<Malcolm
 
 	static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-    static final double REQUEST_TIMEOUT = 0.2;
+    static final double REQUEST_TIMEOUT = 1;
 	
 	private static final Logger logger = LoggerFactory.getLogger(EpicsV4ConnectorService.class);
 	

--- a/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/MalcolmDevice.java
+++ b/org.eclipse.scanning.malcolm.core/src/org/eclipse/scanning/malcolm/core/MalcolmDevice.java
@@ -115,10 +115,9 @@ public class MalcolmDevice<M extends MalcolmModel> extends AbstractMalcolmDevice
 	}
 	
 	public void register() {
-		super.register();
-		
 		try {
 			initialize();
+			super.register();
 		} catch (MalcolmDeviceException e) {
 			logger.error("Could not initialize malcolm device " + getName(), e);
 		}

--- a/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/RunnableDeviceServiceImpl.java
+++ b/org.eclipse.scanning.sequencer/src/org/eclipse/scanning/sequencer/RunnableDeviceServiceImpl.java
@@ -342,16 +342,18 @@ public final class RunnableDeviceServiceImpl implements IRunnableDeviceService, 
 		Collection<DeviceInformation<?>> ret = new ArrayList<>();
 		final Collection<String> names = getRunnableDeviceNames();
 		for (String name : names) {
-
-			if (name==null) continue;
-
-			IRunnableDevice<Object> device = getRunnableDevice(name);
-			if (device==null)  continue;		
-			if (!(device instanceof AbstractRunnableDevice)) continue;
+			try {
+				if (name==null) continue;
 	
-
-			DeviceInformation<?> info = ((AbstractRunnableDevice<?>)device).getDeviceInformation();
-			ret.add(info);
+				IRunnableDevice<Object> device = getRunnableDevice(name);
+				if (device==null)  continue;		
+				if (!(device instanceof AbstractRunnableDevice)) continue;
+				
+				DeviceInformation<?> info = ((AbstractRunnableDevice<?>)device).getDeviceInformation();
+				ret.add(info);
+			} catch (Exception ex) {
+				logger.warn("Error getting device info for : " + name);
+			}
 		}
 		return ret;
 	}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/epics/EpicsV4ConnectorTest.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/epics/EpicsV4ConnectorTest.java
@@ -51,7 +51,7 @@ public class EpicsV4ConnectorTest {
 			// Get the device
 			IMalcolmDevice<ExampleMalcolmModel> modelledDevice = service.getDevice(getTestDeviceName());
 
-			// Get the device state. This should fail as the device does no exist
+			// Get the device state.
 			DeviceState deviceState = modelledDevice.getDeviceState();
 			
 			assertEquals(DeviceState.IDLE, deviceState);
@@ -88,7 +88,7 @@ public class EpicsV4ConnectorTest {
 			// Get the device
 			IMalcolmDevice<ExampleMalcolmModel> modelledDevice = service.getDevice("INVALID_DEVICE");
 
-			// Get the device state. This should fail as the device does no exist
+			// Get the device state. This should fail as the device does not exist
 			modelledDevice.getDeviceState();
 			
 			fail("No exception thrown but one was expected");


### PR DESCRIPTION
Decreased timeout on EPICS V4 connection. 
Only register Malcolm Device with RunnableDeviceService if device is up.
Caught exceptions raised during getting device information.
http://jira.diamond.ac.uk/browse/DAQ-419