### PR TITLE
Fix bug where a scannable couldn't be added to an empty Monitors view

### DIFF
--- a/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/ScannableContentProvider.java
+++ b/org.eclipse.scanning.device.ui/src/org/eclipse/scanning/device/ui/device/ScannableContentProvider.java
@@ -104,17 +104,21 @@ class ScannableContentProvider implements IStructuredContentProvider, IPositionL
 	}
 
 	public void insert(IScannable<?> sscannable, IScannable<?> nscannable) {
-		Map<String, IScannable<?>> copy = new LinkedHashMap<>(content);
-		content.clear();
-		for (String name : copy.keySet()) {
-			if (sscannable.getName()==name || name.equals(sscannable.getName())) {
-				content.put(sscannable.getName(), sscannable);
-				register(nscannable.getName(), nscannable);
-			} else {
-				content.put(name, copy.get(name));
+		if (content.isEmpty()) {
+			register(nscannable.getName(), nscannable);
+		} else {
+			Map<String, IScannable<?>> copy = new LinkedHashMap<>(content);
+			content.clear();
+			for (String name : copy.keySet()) {
+				if (sscannable.getName()==name || name.equals(sscannable.getName())) {
+					content.put(sscannable.getName(), sscannable);
+					register(nscannable.getName(), nscannable);
+				} else {
+					content.put(name, copy.get(name));
+				}
 			}
 		}
-		viewer.refresh();		
+		viewer.refresh();
 	}
 
 	public IScannable<?> last() {

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/ui/ScannableViewerTest2.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/ui/ScannableViewerTest2.java
@@ -1,0 +1,87 @@
+package org.eclipse.scanning.test.ui;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.richbeans.test.ui.ShellTest;
+import org.eclipse.scanning.api.IScannable;
+import org.eclipse.scanning.api.event.scan.DeviceInformation;
+import org.eclipse.scanning.device.ui.device.ScannableViewer;
+import org.eclipse.scanning.server.servlet.Services;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This Test class duplicates the setup of ScannableViewerTest to run a single test which destroys the state
+ * required by other tests in ScannableViewerTest, since individual tests are not fully isolated from each other.
+ *
+ * Ideally, I would have just added a unit test for ScannableContentProvider, but it has no public interface to
+ * test against.
+ */
+@RunWith(SWTBotJunit4ClassRunner.class)
+public class ScannableViewerTest2 extends ShellTest {
+	
+	@BeforeClass
+	public static void createServices() throws Exception {	
+		UISuite.createTestServices(true);
+	}
+	
+	@AfterClass
+	public static void disposeServices() throws Exception {	
+		UISuite.disposeTestServices();
+	}
+	
+	private ScannableViewer viewer;
+
+	@Override
+	protected Shell createShell(Display display) throws Exception {
+		
+		this.viewer = new ScannableViewer();
+	
+		Shell shell = new Shell(display);
+		shell.setText("Monitors");
+		shell.setLayout(new GridLayout(1, false));
+        viewer.createPartControl(shell);
+		
+		shell.pack();
+		shell.setSize(500, 500);
+		shell.open();
+
+		return shell;
+	}
+
+
+	@Test
+	public void somethingFromNothing() throws Exception {
+		
+		try {
+			for (String name : Services.getConnector().getScannableNames()) {
+				synchExec(()->viewer.setScannableSelected(name));
+				synchExec(()->viewer.removeScannable());
+				synchExec(()->viewer.refresh()); // Shouldn't need this! Does not need it in the main UI.
+			}
+			
+			synchExec(()->viewer.reset());
+	
+			assertEquals(0, bot.table(0).rowCount());
+
+			synchExec(()->viewer.addScannable());
+
+			synchExec(()->viewer.refresh()); // Shouldn't need this! Does not need it in the main UI.
+			assertEquals(1, bot.table(0).rowCount());
+		} finally {
+			synchExec(()->viewer.refresh()); // Shouldn't need this! Does not need it in the main UI.
+		}
+	}
+}

--- a/org.eclipse.scanning.test/src/org/eclipse/scanning/test/ui/UISuite.java
+++ b/org.eclipse.scanning.test/src/org/eclipse/scanning/test/ui/UISuite.java
@@ -31,6 +31,7 @@ import uk.ac.diamond.daq.activemq.connector.ActivemqConnectorService;
 	KnownModelsTest.class,
 	BoundingBoxTest.class,
 	ScannableViewerTest.class,
+	ScannableViewerTest2.class,
 	ControlTreeViewerTest.class // Must be last!
 
 })


### PR DESCRIPTION
This was due to ScannableContentProvider.insert() silently doing nothing
if the current list of scannables was empty. Existing tests always had
some scannables, even if they weren't being shown, so didn't trigger the
bug.

Note that the test for this had to go into a new class, as it caused
side effects which caused subsequent tests to fail.